### PR TITLE
Update a couple of copy issues

### DIFF
--- a/documentation/modules/ROOT/pages/build-your-own-container-containerfile.adoc
+++ b/documentation/modules/ROOT/pages/build-your-own-container-containerfile.adoc
@@ -12,7 +12,7 @@ image::buildah.png[Buildah!,width=320,height=78]
 {zwsp} +
 Though we've fixed the issue with `{apache-server-image-insecure}` by using the `buildah` native command line tools to fix it, there are are still additional steps we could take to make this image even more resilient against attack or exploit.  Here are two issues:
 
-* The web server is running on port 80 in the container.  This is a privileged port.  Better to have this run at port run in an privileged port above 1024 (such as 8080)
+* The web server is running on port 80 in the container.  This is a privileged port.  Better to have this run in a privileged port above 1024 (such as 8080)
 * Running as a specific user can be problematic as that user can implicitly have privileges afforded to them via `sudo` (either at runtime or in the ongoing maintenance of the container).  It would be better if we could run the container as the unknown or "anonymous" user
 
 What's more, we have no record of the step-by-step changes we've made to the container that we might store in revision control.  One (valid) option would be to store all the buildah cli commands we issued in a shell script.  

--- a/documentation/modules/ROOT/pages/containers-and-security.adoc
+++ b/documentation/modules/ROOT/pages/containers-and-security.adoc
@@ -622,7 +622,7 @@ The link:https://static.open-scap.org/openscap-1.2/oscap_user_manual.html[Open S
 
 One of podman tools is an oscap compatible scanner, called `oscap-podman` which adapts oscap for use with containers instead of just operating systems.
 
-. To save time, we have provided you with a suitable oval document already.  Let's take a quick look at it by using kbd:[CTRL+p] (or kbd:[CMD+p] on MacOS) to quickly open `rhel-7-oval.xml` (which can be found in the `container-workshop/oval` directory on your instance)
+. To save time, we have provided you with a suitable oval document already.  Let's take a quick look at it by using kbd:[CTRL+p] (or kbd:[CMD+p] on MacOS) to quickly open `rhel-7.oval.xml` (which can be found in the `container-workshop/oval` directory on your instance)
 +
 .OVAL document
 image::oval-document.jpg[OVAL document]
@@ -656,8 +656,8 @@ sudo oscap-podman {apache-server-image-insecure} \#<.>
 ----
 <.> The oscap-podman command must run as `root` due to the container evaluation itself needing elevated privileges.  Hence we use the `sudo` prefix
 <.> This indicates that we are wanting to evaluate the document using the `oval` format (as opposed to XCCDF)
-<.> This is the location of the oval document we just viewed in VS Code
 <.> Indicates that we want the output as an (HTML) report in the specified directory
+<.> This is the location of the oval document we just viewed in VS Code
 --
 ====
 +


### PR DESCRIPTION
When I was doing the Build-a-container workshop last week a couple of little copy issues stuck out, and @bfarr-rh suggested a PR 🙌🏻

In this PR:
- Remove the extra words that are muddling the intro section of the 'Buildah and Containerfiles' page
- Replace a `-` with a `.` in the rhel 7 oval filename to match the file in the sandbox
- Swap footnotes 3 and 4 around in the `oscap-podman` command description to match the order of the args

I don't have VS code installed locally, so these changes haven't been tested.

Thanks for putting together a great workshop!