### PR TITLE
Fix minor issues in lab

### DIFF
--- a/documentation/modules/ROOT/pages/build-your-own-container-containerfile.adoc
+++ b/documentation/modules/ROOT/pages/build-your-own-container-containerfile.adoc
@@ -390,7 +390,7 @@ When a container is run with an arbitrary user, the only thing that we are guara
 podman run \
     --rm \
     -u pass:[$((1000 + ${RANDOM}))] \#<.>
-    -p 8081:80/tcp \ 
+    -p 8080:8080/tcp \
     --name {apache-server-container-name} \
     {apache-server-containerfile-image} \
     /usr/sbin/httpd -DFOREGROUND 
@@ -449,7 +449,7 @@ For starters, it's a little annoying that we have to manually specify the `httpd
 podman run \
     --rm \
     -u pass:[$((1000 + ${RANDOM}))] \
-    -p 8081:8080/tcp
+    -p 8080:8080/tcp
     --name {apache-server-container-name} \
     {apache-server-containerfile-image} \
     #/usr/sbin/httpd -DFOREGROUND#

--- a/documentation/modules/ROOT/pages/deploy-container.adoc
+++ b/documentation/modules/ROOT/pages/deploy-container.adoc
@@ -139,7 +139,7 @@ Let's go back to the container that we finished link:build-your-own-container-co
 
 === OpenShift and Image Registries
 
-In order to be able to run an image in OpenShift or Kubernetes we need to put our image somewhere we're OpenShift can find it.  This usually involves uplaoding the image to either a public or private container registry.  Public registries include Red Hat's link:quay.io[quay.io^] and Docker's link:https://hub.docker.com/[Docker Hub^]
+In order to be able to run an image in OpenShift or Kubernetes we need to put our image somewhere where OpenShift can find it.  This usually involves uploading the image to either a public or private container registry.  Public registries include Red Hat's link:quay.io[quay.io^] and Docker's link:https://hub.docker.com/[Docker Hub^]
 
 One of the features that OpenShift adds to Kubernetes is an in-built container registry called an `ImageStream`.  We're going to create an `ImageStream` to upload our container to where OpenShift can find it.
 

--- a/provisioner/roles/openshift/tasks/setup.yml
+++ b/provisioner/roles/openshift/tasks/setup.yml
@@ -42,3 +42,7 @@
     user_role: edit
     user_name: "student{{ item }}"
   loop: "{{ range(1, num_users + 1)|list }}"
+
+- name: Expose internal registry
+  shell: |
+    oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge


### PR DESCRIPTION
The PR addresses 3 issues:
1. Users are currently unable to retrieve the OpenShift registry and push images. This PR exposes the registry during setup.
2. When spinning up the web container in the Containerfile section of Module 2, the host port is already in use by a container running under the root user. This PR changes the host port to an available port.
3. Some minor typos have been fixed in the lab text.